### PR TITLE
look ahead using path unit

### DIFF
--- a/FPSCamera/Cam/FollowCam.cs
+++ b/FPSCamera/Cam/FollowCam.cs
@@ -6,6 +6,7 @@ namespace FPSCamera.Cam
     using CSkyL.Game.Object;
     using CSkyL.Transform;
     using CSkyL.UI;
+    using FPSCamera.Util;
 
     public abstract class FollowCam : Base
     {
@@ -40,8 +41,9 @@ namespace FPSCamera.Cam
             if (_target is null) _state = new Finish();
             else _inputOffset = CamOffset.G[_target.GetPrefabName()];
             _frames = new Position[4];
+            Position lookPos = _target.LookAhead();
             for (int i = 0; i < 4; ++i) {
-                _frames[i] = _target.GetTargetPos(targetPosIndex);
+                _frames[i] = lookPos;
             }
         }
 
@@ -117,8 +119,8 @@ namespace FPSCamera.Cam
         {
             // code from decompiler : GetSmoothPos()
             uint targetFrame = _target.GetTargetFrame();
-            Position pos1 = _GetFrame(targetFrame - 1 * 16U);
-            Position pos2 = _GetFrame(targetFrame - 0 * 16U);
+            Position pos1 = _GetFrame(targetFrame - 2 * 16U);
+            Position pos2 = _GetFrame(targetFrame - 1 * 16U);
             float t = ((targetFrame & 15U) + SimulationManager.instance.m_referenceTimer) * 0.0625f;
             return Position.Lerp(pos1, pos2, t);
         }
@@ -132,7 +134,7 @@ namespace FPSCamera.Cam
 
         public override void SimulationFrame()
         {
-            _frames[_target.GetLastFrame()] = _target.GetTargetPos(targetPosIndex);
+            _frames[_target.GetLastFrame()] = _target.LookAhead();
         }
 
         public override void RenderOverlay(RenderManager.CameraInfo cameraInfo)
@@ -161,8 +163,7 @@ namespace FPSCamera.Cam
 
         protected const float movementFactor = .1f;
         protected const float heightMovementFactor = .2f;
-        const int targetPosIndex = 3;
-        const float angleFactor = .9f;
+        private float angleFactor => Config.G.LookAheadPercent * 0.01f;
         const float minLookDistance = 0.1f;
 
         protected IDType _id;

--- a/FPSCamera/Configuration/Config.cs
+++ b/FPSCamera/Configuration/Config.cs
@@ -82,6 +82,10 @@ namespace FPSCamera.Configuration
         [Config("LookAhead", "Look ahead",
                 "Camera looks toward the position the target is going to be.")]
         public readonly CfFlag LookAhead = new CfFlag(true);
+        [Config("LookAheadSeconds", "Look seconds ahead", "seconds to look ahead by (depends on speed)")]
+        public readonly CfFloat LookAheadSeconds = new CfFloat(2,0,10);
+        [Config("LookAheadPercent", "% Look ahead", "how much to turn toward look target.")]
+        public readonly CfFloat LookAheadPercent = new CfFloat(90, 0, 100);
         [Config("InstantMoveMax", "Min distance for smooth transition",
                 "In Follow Mode, camera needs to move instantly with\n" +
                 "the target even when smooth transition is enabled.\n" +

--- a/FPSCamera/FPSCamera.csproj
+++ b/FPSCamera/FPSCamera.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>FPSCamera</RootNamespace>
     <AssemblyName>FPSCamera</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <LangVersion>latest</LangVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <AssemblySearchPaths>
@@ -49,6 +50,7 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine" />
+    <Reference Include="ColossalManaged" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Mod.cs" />
@@ -61,6 +63,9 @@
     <Compile Include="Cam\VehicleCam.cs" />
     <Compile Include="Cam\WalkThruCam.cs" />
     <Compile Include="Patch\RenderOverlayPatch.cs" />
+    <Compile Include="Util\MathUtil.cs" />
+    <Compile Include="Util\NetUtil.cs" />
+    <Compile Include="Util\PathUtil.cs" />
     <Compile Include="ThreadingExtension.cs" />
     <Compile Include="UI\Style.cs" />
     <Compile Include="UI\MainPanel.cs" />

--- a/FPSCamera/UI/OptionsMenu.cs
+++ b/FPSCamera/UI/OptionsMenu.cs
@@ -107,6 +107,12 @@ namespace FPSCamera.UI
                 _settings.Add(group.Add<ToggleSetting>(props.Swap(Config.G.StickToFrontVehicle)));
                 _settings.Add(group.Add<ToggleSetting>(props.Swap(Config.G.LookAhead)));
 
+                props.stepSize = 0.1f; props.valueFormat = "R";
+                _settings.Add(group.Add<SliderSetting>(props.Swap(Config.G.LookAheadSeconds)));
+
+                props.stepSize = 10f; props.valueFormat = "F0";
+                _settings.Add(group.Add<SliderSetting>(props.Swap(Config.G.LookAheadPercent)));
+
                 props.stepSize = 1f; props.valueFormat = "F0";
                 _settings.Add(group.Add<SliderSetting>(props.Swap(Config.G.InstantMoveMax)));
 

--- a/FPSCamera/Util/MathUtil.cs
+++ b/FPSCamera/Util/MathUtil.cs
@@ -5,9 +5,13 @@ namespace FPSCamera.Util
 {
     public static class MathUtil
     {
+        /// <summary>
+        /// Creates Bezier using start/end pos/dir
+        /// </summary>
+        /// <param name="startSmooth">true for middle nodes and transitions</param>
+        /// <param name="endSmooth">true for middle nodes and transitions</param>
         /// <param name="startDir">should be going toward the end of the bezier.</param>
         /// <param name="endDir">should be going toward the start of the  bezier.</param>
-        /// <returns></returns>
         public static Bezier3 Bezier3ByDir(Vector3 startPos, Vector3 startDir, Vector3 endPos, Vector3 endDir, bool startSmooth = false, bool endSmooth = false)
         {
             NetSegment.CalculateMiddlePoints(
@@ -23,6 +27,10 @@ namespace FPSCamera.Util
                 c = MiddlePoint2,
             };
         }
+
+        /// <summary>
+        /// Calculates length of the Bezier arc by subdividing it into several <paramref name="step"/>s.
+        /// </summary>
         public static float ArcLength(this Bezier3 beizer, float step = 0.1f)
         {
             float ret = 0;
@@ -38,6 +46,13 @@ namespace FPSCamera.Util
             return ret;
         }
 
+        /// <summary>
+        /// Accurately travels a certain distance on <paramref name="beizer"/> starting from <code>bezier.a</code>
+        /// if <paramref name="distance"/> is larger than bezier length then method returns 1.
+        /// </summary>
+        /// <param name="distance">must be positive.</param>
+        /// <param name="step">precision of calculation</param>
+        /// <returns>bezier offset that is <paramref name="distance"/> away from start point</returns>
         public static float ArcTravel(this Bezier3 beizer, float distance, float step = 0.1f)
         {
             float accDistance = 0;

--- a/FPSCamera/Util/MathUtil.cs
+++ b/FPSCamera/Util/MathUtil.cs
@@ -1,0 +1,59 @@
+﻿using ColossalFramework.Math;
+using UnityEngine;
+
+namespace FPSCamera.Util
+{
+    public static class MathUtil
+    {
+        /// <param name="startDir">should be going toward the end of the bezier.</param>
+        /// <param name="endDir">should be going toward the start of the  bezier.</param>
+        /// <returns></returns>
+        public static Bezier3 Bezier3ByDir(Vector3 startPos, Vector3 startDir, Vector3 endPos, Vector3 endDir, bool startSmooth = false, bool endSmooth = false)
+        {
+            NetSegment.CalculateMiddlePoints(
+                startPos, startDir,
+                endPos, endDir,
+                startSmooth, endSmooth,
+                out Vector3 MiddlePoint1, out Vector3 MiddlePoint2);
+            return new Bezier3
+            {
+                a = startPos,
+                d = endPos,
+                b = MiddlePoint1,
+                c = MiddlePoint2,
+            };
+        }
+        public static float ArcLength(this Bezier3 beizer, float step = 0.1f)
+        {
+            float ret = 0;
+            float t;
+            for (t = step; t < 1f; t += step) {
+                float len = (beizer.Position(t) - beizer.Position(t - step)).magnitude;
+                ret += len;
+            }
+            {
+                float len = (beizer.d - beizer.Position(t - step)).magnitude;
+                ret += len;
+            }
+            return ret;
+        }
+
+        public static float ArcTravel(this Bezier3 beizer, float distance, float step = 0.1f)
+        {
+            float accDistance = 0;
+            float t;
+            for (t = step; ; t += step) {
+                if (t > 1f) t = 1f;
+                float len = (beizer.Position(t) - beizer.Position(t - step)).magnitude;
+                accDistance += len;
+                if (accDistance >= distance) {
+                    // travel backward to correct position.
+                    t = beizer.Travel(t, distance - accDistance);
+                    return t;
+                }
+                if (t >= 1f)
+                    return 1;
+            }
+        }
+    }
+}

--- a/FPSCamera/Util/NetUtil.cs
+++ b/FPSCamera/Util/NetUtil.cs
@@ -1,0 +1,19 @@
+﻿namespace FPSCamera.Util
+{
+    public static class NetUtil
+    {
+        public static NetManager netMan = NetManager.instance;
+        private static NetNode[] nodeBuffer_ = netMan.m_nodes.m_buffer;
+        private static NetSegment[] segmentBuffer_ = netMan.m_segments.m_buffer;
+        private static NetLane[] laneBuffer_ = netMan.m_lanes.m_buffer;
+
+        public static ref NetNode ToNode(this ushort id) => ref nodeBuffer_[id];
+        public static ref NetSegment ToSegment(this ushort id) => ref segmentBuffer_[id];
+        public static ref NetLane ToLane(this uint id) => ref laneBuffer_[id];
+
+        public static bool IsStartNode(ushort segmentId, ushort nodeId) =>
+            segmentId.ToSegment().m_startNode == nodeId;
+        public static bool IsStartNode(this ref NetSegment segment, ushort nodeId) =>
+            segment.m_startNode == nodeId;
+    }
+}

--- a/FPSCamera/Util/NetUtil.cs
+++ b/FPSCamera/Util/NetUtil.cs
@@ -2,7 +2,7 @@
 {
     public static class NetUtil
     {
-        public static NetManager netMan = NetManager.instance;
+        private static NetManager netMan = NetManager.instance;
         private static NetNode[] nodeBuffer_ = netMan.m_nodes.m_buffer;
         private static NetSegment[] segmentBuffer_ = netMan.m_segments.m_buffer;
         private static NetLane[] laneBuffer_ = netMan.m_lanes.m_buffer;

--- a/FPSCamera/Util/PathUtil.cs
+++ b/FPSCamera/Util/PathUtil.cs
@@ -1,0 +1,219 @@
+﻿using ColossalFramework.Math;
+using CSkyL.Game.Object;
+using CSkyL.Transform;
+using FPSCamera.Configuration;
+using System;
+using UnityEngine;
+
+namespace FPSCamera.Util
+{
+    internal static class PathUtil
+    {
+        const int targetPosIndex = 3;
+        internal const float BYTE2FLOAT_OFFSET = 1f / 255;
+
+        internal static ref PathUnit ToPathUnit(this uint id) => ref PathManager.instance.m_pathUnits.m_buffer[id];
+        internal static ref NetLane GetLane(this ref PathUnit.Position pathPos) => ref PathManager.GetLaneID(pathPos).ToLane();
+        internal static NetInfo.Lane GetLaneInfo(this ref PathUnit.Position pathPos) =>
+            pathPos.m_segment.ToSegment().Info?.m_lanes?[pathPos.m_lane];
+
+        internal static bool OnPedestrianLane(this ref PathUnit.Position pathPos) =>
+            pathPos.GetLaneInfo().m_laneType == NetInfo.LaneType.Pedestrian;
+
+
+        internal static bool CalculateTransitionBezier(this PathUnit pathUnit, byte finePathPosIndex, out Bezier3 bezier)
+        {
+            bezier = default;
+            if ((finePathPosIndex & 1) == 0) return false; // transition is odd
+            if ((finePathPosIndex >> 1) >= pathUnit.m_positionCount) return false; // bad index
+            var pathPos1 = pathUnit.GetPosition(finePathPosIndex >> 1);
+            if (pathPos1.m_segment == 0) return false;
+            if (!pathUnit.GetNextPosition(finePathPosIndex >> 1, out var pathPos2)) return false;
+            bezier = pathPos1.CalculateTransitionBezier(pathPos2);
+            return true;
+        }
+
+        internal static void CalculatePositionAndDirection(this PathUnit.Position pathPos, byte offset, out Vector3 pos, out Vector3 dir)
+        {
+            pathPos.GetLane().CalculatePositionAndDirection(
+                offset * BYTE2FLOAT_OFFSET, out pos, out dir);
+            dir.Normalize();
+            if (offset == 0) dir = -dir;
+        }
+
+        internal static Bezier3 CalculateTransitionBezier(this PathUnit.Position pathPos1, PathUnit.Position pathPos2)
+        {
+            pathPos1.CalculatePositionAndDirection(
+        pathPos1.m_offset, out var pos1, out var dir1);
+
+            if (pathPos1.GetNodeID() == 0) {
+                // use pathPos1 offset because we are transitioning from road to pavement.
+                pathPos2.CalculatePositionAndDirection(
+                pathPos1.m_offset, out var pos2, out var dir2);
+                // straight line:
+                dir1 = (pos2 - pos1).normalized;
+                dir2 = -dir1;
+                return MathUtil.Bezier3ByDir(
+                    pos1, dir1, pos2, dir2);
+            } else {
+                byte offset2 = pathPos2.GetEndOffsetToward(pathPos1);
+                pathPos2.CalculatePositionAndDirection(
+                offset2, out var pos2, out var dir2);
+                if (pathPos1.OnPedestrianLane() && pathPos1.m_segment == pathPos2.m_segment) {
+                    // pedestrian crossing or going to vehicle : straight line
+                    dir1 = (pos2 - pos1).normalized;
+                    dir2 = -dir1;
+                    return MathUtil.Bezier3ByDir(pos1, dir1, pos2, dir2);
+                }
+                else {
+                    return MathUtil.Bezier3ByDir(
+                        pos1, dir1, pos2, dir2, true, true);
+                }
+            }
+        }
+
+        internal static byte GetEndOffsetToward(this PathUnit.Position pathPos, PathUnit.Position pathPos0)
+        {
+            ushort nodeId = pathPos0.GetNodeID();
+            bool startNode = pathPos.m_segment.ToSegment().IsStartNode(nodeId);
+            if (startNode) return 0;
+            else return 255;
+        }
+
+        internal static ushort GetNodeID(this ref PathUnit.Position pathPos)
+        {
+            switch (pathPos.m_offset) {
+            case 255: return pathPos.m_segment.ToSegment().m_endNode;
+            case 0: return pathPos.m_segment.ToSegment().m_startNode;
+            default: return 0;
+
+            }
+        }
+
+        internal static Vector3 GetPosition(this PathUnit.Position pathPos) =>
+            pathPos.GetLane().CalculatePosition(pathPos.m_offset * BYTE2FLOAT_OFFSET);
+
+
+        internal static Position LookAhead(this IObjectToFollow target)
+        {
+            return target.TravelBy(seconds: Config.G.LookAheadSeconds, minDistance: 4f);
+        }
+
+        internal static Position TravelBy(this IObjectToFollow target, float seconds, float minDistance)
+        {
+            try {
+                bool fail = target is Pedestrian pedestrian && (pedestrian.IsWaitingTransit || pedestrian.IsEnteringVehicle || pedestrian.IsHangingAround);
+                if(!fail && TravelImpl(target, seconds, minDistance, out Vector3 lastPos)) {
+                    return Position._FromVec(lastPos);
+                }
+            } catch (Exception ex) {
+                Debug.LogException(ex);
+            }
+            return target.GetTargetPos(targetPosIndex);
+        }
+
+        /// <param name="lastPos">pos0 if no path was found, otherwise position after distance</param>
+        /// <returns>false if no path was found</returns>
+        private static bool TravelImpl(IObjectToFollow target, float seconds, float minDistance, out Vector3 lastPos)
+        {
+            target.GetPathInfo(
+                out uint pathUnitID,
+                out byte lastOffset,
+                out byte finePathPositionIndex,
+                out Vector3 pos0,
+                out Vector3 velocity0);
+            lastPos = pos0;
+            if (pathUnitID == 0) return false;
+
+
+            float speed = velocity0.magnitude * 5; // meters per second
+            speed = Math.Max(5, speed);
+            float distance = speed * seconds;
+            distance = Math.Max(distance, minDistance);
+            float accDistance = 0;
+
+            if (finePathPositionIndex == 255) {
+                finePathPositionIndex = 0;// initial position
+                if (!pathUnitID.ToPathUnit().CalculatePathPositionOffset(
+                    0, pos0, out lastOffset)) {
+                    return false;
+                }
+            }
+
+            var pathPos = pathUnitID.ToPathUnit().GetPosition(finePathPositionIndex >> 1);
+            if (pathPos.m_segment == 0) return false;
+
+            Bezier3 bezier;
+            if ((finePathPositionIndex & 1) == 0) {
+                bezier = pathPos.GetLane().m_bezier;
+                bezier = bezier.Cut(lastOffset * BYTE2FLOAT_OFFSET, pathPos.m_offset * BYTE2FLOAT_OFFSET);
+            }
+            else {
+                pathUnitID.ToPathUnit().CalculateTransitionBezier(finePathPositionIndex, out bezier);
+                bezier = bezier.Cut(lastOffset * BYTE2FLOAT_OFFSET, 1);
+            }
+
+            while (true) {
+                if (!bezier.TryTravel(ref accDistance, distance, ref lastPos)) {
+                    return true;
+                }
+
+                //if (pathPos.GetNodeID() == 0) {
+                //    // change transport type
+                //    return pathPos.GetPosition();
+                //}
+
+                var pathPos0 = pathPos;
+                finePathPositionIndex++;
+                if (!RollAndGetPathPos(ref pathUnitID, ref finePathPositionIndex, out pathPos))
+                    return true;
+                if ((finePathPositionIndex & 1) != 0) {
+                    pathUnitID.ToPathUnit().CalculateTransitionBezier(finePathPositionIndex, out bezier);
+                }
+                else {
+                    bezier = pathPos.GetLane().m_bezier;
+                    byte offset1;
+                    if (pathPos.m_segment != pathPos0.m_segment) {
+                        offset1 = pathPos.GetEndOffsetToward(pathPos0);
+                    }
+                    else {
+                        offset1 = pathPos0.m_offset;
+                    }
+                    float t1 = offset1 * BYTE2FLOAT_OFFSET;
+                    float t2 = pathPos.m_offset * BYTE2FLOAT_OFFSET;
+                    bezier = bezier.Cut(t1, t2);
+                }
+            }
+        }
+
+        static bool TryTravel(this Bezier3 bezier, ref float accDistance, float distance, ref Vector3 lastPos)
+        {
+            float l = bezier.ArcLength();
+            if (l == 0 || l > 1000) return true; // bad bezier
+            if (accDistance + l >= distance) {
+                float t = bezier.ArcTravel(distance - accDistance);
+                bezier = bezier.Cut(0, t);
+            }
+            accDistance += l;
+            lastPos = bezier.d;
+            return accDistance < distance;
+        }
+
+        static bool RollAndGetPathPos(ref uint pathUnitID, ref byte finePathIndex, out PathUnit.Position pathPos)
+        {
+            if (finePathIndex >= 24) {
+                finePathIndex = 0;
+                pathUnitID = pathUnitID.ToPathUnit().m_nextPathUnit;
+            }
+            if (pathUnitID == 0 || (finePathIndex >> 1) >= pathUnitID.ToPathUnit().m_positionCount) {
+                pathPos = default;
+                return false;
+            }
+
+            pathPos = pathUnitID.ToPathUnit().GetPosition(finePathIndex >> 1);
+            if (pathPos.m_segment == 0) return false;
+            return true;
+        }
+
+    }
+}

--- a/FPSCamera/Util/PathUtil.cs
+++ b/FPSCamera/Util/PathUtil.cs
@@ -93,12 +93,21 @@ namespace FPSCamera.Util
         internal static Vector3 GetPosition(this PathUnit.Position pathPos) =>
             pathPos.GetLane().CalculatePosition(pathPos.m_offset * BYTE2FLOAT_OFFSET);
 
-
+        /// <summary>
+        /// gets look ahead position.
+        /// </summary>
         internal static Position LookAhead(this IObjectToFollow target)
         {
             return target.TravelBy(seconds: Config.G.LookAheadSeconds, minDistance: 4f);
         }
 
+        /// <summary>
+        /// returns a position <paramref name="seconds"/> ahead on <paramref name="target"/>'s path.
+        /// if not possible then returns target position instead.
+        /// </summary>
+        /// <param name="target">object to follow</param>
+        /// <param name="seconds">seconds to travel based on speed</param>
+        /// <param name="minDistance">minimum distance to travel at low speed</param>
         internal static Position TravelBy(this IObjectToFollow target, float seconds, float minDistance)
         {
             try {
@@ -112,7 +121,7 @@ namespace FPSCamera.Util
             return target.GetTargetPos(targetPosIndex);
         }
 
-        /// <param name="lastPos">pos0 if no path was found, otherwise position after distance</param>
+        /// <param name="lastPos">current position if no path was found, otherwise position that is <paramref name="seconds"/> or <paramref name="minDistance"/> ahead</param>
         /// <returns>false if no path was found</returns>
         private static bool TravelImpl(IObjectToFollow target, float seconds, float minDistance, out Vector3 lastPos)
         {


### PR DESCRIPTION
[FPSCamera.zip](https://github.com/Asu4ni/CitiesSkylines-FPSCamera/files/10140327/FPSCamera.zip)
fixes #55 . see issue for more detail
- Created Util classes used calculate certain distance ahead.
- If that is not possible (target reached End of path,  is wondering around, is waiting for bus, ...) then I fall back to the old target pos (currently in the WS version we always use target pos).
- Settings look like this:
![image](https://user-images.githubusercontent.com/26344691/205274888-1c32d2dd-2608-4e7f-8fc2-7760741c5546.png)


see also:
[SelecetedInstanceDebugOverlay.zip](https://github.com/Asu4ni/CitiesSkylines-FPSCamera/files/10140328/ExperimentMod-V2.5.0.20376-11d9202-Debug.zip) : useful to see debug overlay from above
[Vehicle Debug Overlay](https://steamcommunity.com/sharedfiles/filedetails/?id=2883351966) : useful to understand how path unit works